### PR TITLE
Include LXQt::Settings in order to compile.

### DIFF
--- a/lxqt-admin-time/timeadmindialog.cpp
+++ b/lxqt-admin-time/timeadmindialog.cpp
@@ -33,6 +33,8 @@
 #include <QMap>
 #include <QDebug>
 
+#include <LXQt/Settings>
+
 #include "datetime.h"
 #include "timezone.h"
 


### PR DESCRIPTION
lxqt-admin fails to compile.