### PR TITLE
Update lxqt-admin-time_zh_TW.desktop

### DIFF
--- a/lxqt-admin-time/translations/lxqt-admin-time_zh_TW.desktop
+++ b/lxqt-admin-time/translations/lxqt-admin-time_zh_TW.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name[zh_TW]=日期與時間
-GenericName[ja]=日期與時間設定
-Comment[ja]=設定系統的日期與時間
+GenericName[zh_TW]=日期與時間設定
+Comment[zh_TW]=設定系統的日期與時間
 
 #TRANSLATIONS_DIR=translations


### PR DESCRIPTION
Fix desktop-file-validate errors:

usr/share/applications/lxqt-admin-time.desktop: error: file contains multiple keys named "GenericName[ja]" in group "Desktop Entry"
usr/share/applications/lxqt-admin-time.desktop: error: file contains multiple keys named "Comment[ja]" in group "Desktop Entry"