### PR TITLE
replace forgotten autoconversion with Q1LC()

### DIFF
--- a/lxqt-admin-user/usermanager.cpp
+++ b/lxqt-admin-user/usermanager.cpp
@@ -377,7 +377,7 @@ bool UserManager::modifyGroup(GroupInfo* group, GroupInfo* newSettings) {
     if(newSettings->members() != group->members()) {
         isDirty = true;
         command << QStringLiteral("-M");  // Set the list of group members.
-        command << newSettings->members().join(',');
+        command << newSettings->members().join(Q1LC(','));
     }
     command << QStringLiteral("-n");
 #endif


### PR DESCRIPTION
This one was forgotten probably because it was inside `#ifdef Q_OS_FREEBSD`. This made building lxqt-admin with Qt 5.11 on FreeBSD fail with an error.