### PR TITLE
timezone.ui: remove extronous text from label

### DIFF
--- a/lxqt-admin-time/timezone.ui
+++ b/lxqt-admin-time/timezone.ui
@@ -22,9 +22,6 @@
      </item>
      <item row="0" column="1">
       <widget class="QLabel" name="label_timezone">
-       <property name="text">
-        <string>TextLabel</string>
-       </property>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
The actual label text actually got set on the code.