### PR TITLE
Add lxqt-admin-user-password - external gui utility for changing pass…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,5 +42,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD" OR ${CMAKE_SYSTEM_NAME} MATCHES "NetBS
     message(WARNING "${CMAKE_SYSTEM_NAME} is not supported by lxqt-admin-time")
 else()
     add_subdirectory(lxqt-admin-user)
+    add_subdirectory(lxqt-admin-user-password)
     add_subdirectory(lxqt-admin-time)
 endif()

--- a/lxqt-admin-user-password/CMakeLists.txt
+++ b/lxqt-admin-user-password/CMakeLists.txt
@@ -1,0 +1,54 @@
+project(lxqt-admin-user-password)
+
+# build static helper class first
+include_directories (
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+# define sources
+file(GLOB HEADERS *.h)
+file(GLOB UI_FORMS *.ui)
+file(GLOB SOURCES *.cpp)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(ALL_SOURCES
+    ${SOURCES}
+    ${UI_FORMS}
+    ${HEADERS}
+)
+
+add_definitions(-DPROJECT_NAME="${PROJECT_NAME}")
+
+# Translations **********************************
+lxqt_translate_ts(muser_QM_FILES
+    UPDATE_TRANSLATIONS YES
+    UPDATE OPTIONS
+    SOURCES
+    ${MOCS}
+    ${SOURCES}
+    ${UI_FORMS}
+    INSTALL_DIR
+    "${LXQT_TRANSLATIONS_DIR}/${PROJECT_NAME}"
+    PULL_TRANSLATIONS NO
+)
+
+lxqt_app_translation_loader(lxqt-admin-user-password_QM_LOADER ${PROJECT_NAME})
+#************************************************
+
+add_executable(lxqt-admin-user-password
+    ${ALL_SOURCES}
+    ${lxqt-admin-user-password_QM_FILES}
+    ${lxqt-admin-user-password_QM_LOADER}
+)
+
+target_link_libraries(lxqt-admin-user-password
+    KF5::WindowSystem
+    Qt5::Widgets
+    lxqt
+    pam
+)
+
+install(TARGETS lxqt-admin-user-password RUNTIME DESTINATION bin)

--- a/lxqt-admin-user-password/changepassworddialog.cpp
+++ b/lxqt-admin-user-password/changepassworddialog.cpp
@@ -1,0 +1,254 @@
+#include "changepassworddialog.h"
+#include "ui_changepassworddialog.h"
+
+#include <security/pam_appl.h>
+
+#include <QMessageBox>
+#include <QLabel>
+#include <QLineEdit>
+
+#include <QDebug>
+
+int ChangePasswordDialog::conversation(int num_msg,
+                                       const struct pam_message **msg,
+                                       struct pam_response **resp,
+                                       void *appdata_ptr)
+{
+    *resp = 0;
+    ChangePasswordDialog *dialog = 0;
+    if (!(num_msg && (dialog = (ChangePasswordDialog *) appdata_ptr) && ! dialog->_userAbort))
+        return PAM_CONV_ERR;
+
+    int answerSize = num_msg * sizeof(struct pam_response);
+    struct pam_response *answer = 0;
+
+    if (!(answer = (struct pam_response *) malloc(answerSize)))
+        return PAM_BUF_ERR;
+
+    memset(answer, 0, answerSize);
+
+    bool labelAdded = false;
+    for (int i = 0; i < num_msg; i++)
+    {
+        QString message = QString::fromLocal8Bit(msg[i]->msg);
+        switch (msg[i]->msg_style)
+        {
+            case PAM_PROMPT_ECHO_OFF:
+            {
+                labelAdded = true;
+                dialog->addLabel(message, true);
+            }
+            break;
+            case PAM_PROMPT_ECHO_ON:
+            {
+                labelAdded = true;
+                dialog->addLabel(message, false);
+            }
+            break;
+            case PAM_ERROR_MSG:
+                dialog->addWarning(message);
+            break;
+            case PAM_TEXT_INFO :
+                dialog->addMessage(message);
+            break;
+            default:
+            {
+                free(answer);
+                return PAM_CONV_ERR;
+            }
+        }
+    }
+
+    if (!labelAdded)
+    {
+        *resp = answer;
+        return PAM_SUCCESS;
+    }
+
+    dialog->showWarnings();
+    dialog->showMessages();
+
+    if (!(dialog->exec() == QDialog::Accepted))
+    {
+        dialog->_userAbort = true;
+        free(answer);
+        return PAM_CONV_ERR;
+    }
+
+    for (int i = 0, j = 0; i < num_msg; i++)
+    {
+        switch (msg[i]->msg_style)
+        {
+            case PAM_PROMPT_ECHO_OFF:
+            case PAM_PROMPT_ECHO_ON:
+            {
+                char *str = strdup(qPrintable(dialog->values().at(j)));
+                j++;
+                if (!str)
+                {
+                    for (int k = 0; k < i; k++)
+                        free(answer[k].resp);
+                    free(answer);
+                    return PAM_BUF_ERR;
+                }
+                answer[i].resp = str;
+            }
+            break;
+            default :
+                break;
+        }
+    }
+
+    *resp =  answer;
+    return PAM_SUCCESS;
+}
+
+ChangePasswordDialog::ChangePasswordDialog(QWidget *parent)
+: QDialog(parent)
+, _ui(new Ui::ChangePasswordDialog)
+, _userAbort(false)
+{
+    _ui->setupUi(this);
+}
+
+ChangePasswordDialog::~ChangePasswordDialog()
+{
+    delete _ui;
+}
+
+const QString &ChangePasswordDialog::user() const
+{
+    return _user;
+}
+
+void ChangePasswordDialog::setUser(const QString &user)
+{
+    if (_user == user)
+        return;
+
+    _user = user;
+    setWindowTitle(tr("Change password for user \"%1\"").arg(_user));
+}
+
+void ChangePasswordDialog::addWarning(const QString &warning)
+{
+    _warnings.append(warning);
+}
+
+void ChangePasswordDialog::addMessage(const QString &message)
+{
+    _messages.append(message);
+}
+
+void ChangePasswordDialog::addLabel(const QString &textLabel, bool isShadow)
+{
+    QLabel *label = new QLabel();;
+    QLineEdit *lineEdit = new QLineEdit();
+
+    label->setText(textLabel);
+    lineEdit->setEchoMode(isShadow ? QLineEdit::Password : QLineEdit::Normal);
+
+    _ui->_verticalLayout->addWidget(label);
+    _ui->_verticalLayout->addWidget(lineEdit);
+}
+
+const QList<QString> &ChangePasswordDialog::values() const
+{
+    return _values;
+}
+
+bool ChangePasswordDialog::changePassword()
+{
+    if (_user.isEmpty())
+        return false;
+
+    _userAbort = false;
+
+    pam_handle_t *pamh = NULL;
+
+    pam_conv pam_conversation;
+    pam_conversation.conv = ChangePasswordDialog::conversation;
+    pam_conversation.appdata_ptr = (void *) this;
+
+    int result = 0;
+
+    result = pam_start("password", qPrintable(_user), &pam_conversation, &pamh);
+
+    if (result != PAM_SUCCESS)
+    {
+        QMessageBox::critical(parentWidget(), tr("PAM transaction"), tr("PAM transaction not started.\nError code: %1").arg(result));
+        return false;
+    }
+
+    bool isChanged = ((result = pam_chauthtok(pamh, 0)) == PAM_SUCCESS);
+
+    showWarnings();
+    showMessages();
+
+    if ((result =  pam_end(pamh, result)) != PAM_SUCCESS)
+        QMessageBox::critical(parentWidget(), tr("PAM transaction"), tr("PAM transaction not finished.\nError code: %1").arg(result));
+
+    return isChanged;
+}
+
+void ChangePasswordDialog::reset()
+{
+    int size = _ui->_verticalLayout->count();
+    for (int i = 0; i < size; i++)
+    {
+        QLayoutItem *layoutItem = _ui->_verticalLayout->itemAt(0);
+        QWidget *widget = layoutItem->widget();
+        _ui->_verticalLayout->removeItem(layoutItem);
+        if (widget)
+            delete widget;
+    }
+}
+
+void ChangePasswordDialog::showMessages()
+{
+    if (_messages.size())
+    {
+        QMessageBox::information(parentWidget(), windowTitle(), _messages.join(QStringLiteral("\n")));
+        _messages.clear();
+    }
+}
+
+void ChangePasswordDialog::showWarnings()
+{
+    if (_warnings.size())
+    {
+        QMessageBox::warning(parentWidget(), windowTitle(), _warnings.join(QStringLiteral("\n")));
+        _warnings.clear();
+    }
+}
+
+void ChangePasswordDialog::showEvent(QShowEvent *event)
+{
+    if (!_ui->_verticalLayout->count())
+        return;
+    _ui->_verticalLayout->addStretch(1);
+    QDialog::showEvent(event);
+    _ui->_verticalLayout->itemAt(1)->widget()->setFocus();
+
+}
+
+void ChangePasswordDialog::accept()
+{
+    _values.clear();
+
+    int size = _ui->_verticalLayout->count();
+    for (int i = 0; (i + 1) < size; i += 2)
+    {
+        QLineEdit *lineEdit = qobject_cast<QLineEdit *>(_ui->_verticalLayout->itemAt(i + 1)->widget());
+        if (lineEdit)
+            _values.append( lineEdit->text() );
+    }
+    reset();
+    QDialog::accept();
+}
+
+void ChangePasswordDialog::reject()
+{
+    reset();
+    QDialog::reject();
+}

--- a/lxqt-admin-user-password/changepassworddialog.h
+++ b/lxqt-admin-user-password/changepassworddialog.h
@@ -1,0 +1,54 @@
+#ifndef CHANGEPASSWORDDIALOG_H
+#define CHANGEPASSWORDDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class ChangePasswordDialog;
+}
+
+class ChangePasswordDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    static int conversation(int, const struct pam_message**, struct pam_response**, void *);
+
+    ChangePasswordDialog(QWidget */*parent*/ = 0);
+    virtual ~ChangePasswordDialog();
+
+    const QString &user() const;
+    void setUser(const QString &user);
+
+    void addWarning(const QString &);
+    void addMessage(const QString &);
+    void addLabel(const QString &, bool);
+
+    const QList<QString> &values() const;
+    bool changePassword();
+
+protected:
+    void reset();
+    void showMessages();
+    void showWarnings();
+
+    virtual void showEvent(QShowEvent *event);
+
+public slots:
+    virtual void accept();
+    virtual void reject();
+
+protected:
+    Ui::ChangePasswordDialog *_ui;
+
+    bool _userAbort;
+
+    QString _user;
+
+    QStringList _warnings;
+    QStringList _messages;
+    QList<bool> _shadows;
+    QList<QString> _values;
+};
+
+#endif // CHANGEPASSWORDDIALOG_H

--- a/lxqt-admin-user-password/changepassworddialog.ui
+++ b/lxqt-admin-user-password/changepassworddialog.ui
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ChangePasswordDialog</class>
+ <widget class="QDialog" name="ChangePasswordDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>67</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true"/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="_buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="_verticalLayout"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>_buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ChangePasswordDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>_buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ChangePasswordDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/lxqt-admin-user-password/main.cpp
+++ b/lxqt-admin-user-password/main.cpp
@@ -1,0 +1,71 @@
+#include <QCommandLineParser>
+#include <QMessageBox>
+#include <QTextStream>
+#include <QIcon>
+#include <LXQt/Application>
+#include <pwd.h>
+#include <grp.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include "changepassworddialog.h"
+
+int main(int argc, char **argv)
+{
+    QApplication::setSetuidAllowed(true);
+    LXQt::Application app(argc, argv, true);
+    app.setQuitOnLastWindowClosed(false);
+
+    QApplication::setApplicationName(QSL(PROJECT_NAME));
+    QCommandLineParser parser;
+    QString user;
+
+    parser.setApplicationDescription(QObject::tr("LXQt helper for password changing via PAM stack"));
+    parser.addHelpOption();
+
+    QCommandLineOption userOption(QStringList() << QSL("u") << QSL("user"),
+                                  QObject::tr("User name for password changing"),
+                                  QSL("user"));
+    parser.addOption(userOption);
+
+    parser.process(app);
+
+    if (parser.isSet(userOption))
+    {
+        user = parser.value(userOption);
+
+        struct passwd *pw = getpwnam(qPrintable(user));
+        if (!pw)
+        {
+            QMessageBox::critical(nullptr,
+                                  QSL(PROJECT_NAME),
+                                  QObject::tr("User %1 does not exists").arg(user));
+            lxqtApp->quit();
+            return 1;
+        }
+        if (getuid() && (pw->pw_uid != getuid()))
+        {
+            QMessageBox::critical(nullptr,
+                                  QSL(PROJECT_NAME),
+                                  QObject::tr("You may not view or modify password information for %1").arg(user));
+            lxqtApp->quit();
+            return 1;
+        }
+    }
+    else
+        user = QString::fromLocal8Bit(qgetenv("USER"));
+
+    ChangePasswordDialog dialog;
+    dialog.setWindowIcon(QIcon::fromTheme(QSL("preferences-system")));
+    dialog.setUser(user);
+
+    bool result = dialog.changePassword();
+
+    if (!result)
+    {
+        QTextStream(stderr) << QObject::tr("Password does not changed") << endl;
+        lxqtApp->quit();
+        return 1;
+    }
+
+    return 0;
+}

--- a/lxqt-admin-user-password/translations/lxqt-admin-user-password.ts
+++ b/lxqt-admin-user-password/translations/lxqt-admin-user-password.ts
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru_RU" sourcelanguage="ru">
+<context>
+    <name>ChangePasswordDialog</name>
+    <message>
+        <location filename="../changepassworddialog.cpp" line="130"/>
+        <source>Change password for user &quot;%1&quot;</source>
+        <translation>Смена пароля для пользователя &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../changepassworddialog.cpp" line="179"/>
+        <location filename="../changepassworddialog.cpp" line="189"/>
+        <source>PAM transaction</source>
+        <translation>Транзакция PAM</translation>
+    </message>
+    <message>
+        <location filename="../changepassworddialog.cpp" line="179"/>
+        <source>PAM transaction not started.
+Error code: %1</source>
+        <translation>Транзакция PAM не стартовала.
+Код ошибки: %1</translation>
+    </message>
+    <message>
+        <location filename="../changepassworddialog.cpp" line="189"/>
+        <source>PAM transaction not finished.
+Error code: %1</source>
+        <translation>Транзакция PAM не завершена.
+Код ошибки: %1</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="22"/>
+        <source>LXQt helper for password changing via PAM stack</source>
+        <translation>Графическое приложение LXQt для смены пароля через PAM стек</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="26"/>
+        <source>User name for password changing</source>
+        <translation>Логин пользователя для смены пароля</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="41"/>
+        <source>User %1 does not exists</source>
+        <translation>Пользователь %1 не существует</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="49"/>
+        <source>You may not view or modify password information for %1</source>
+        <translation>Вы не можете получить или изменить информацию о пароле пользователя %1</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="65"/>
+        <source>Password does not changed</source>
+        <translation>Пароль не изменен</translation>
+    </message>
+</context>
+</TS>

--- a/lxqt-admin-user/CMakeLists.txt
+++ b/lxqt-admin-user/CMakeLists.txt
@@ -11,6 +11,9 @@ set ( lxqt-admin-user_SRCS
     userdialog.cpp
     groupdialog.cpp
     usermanager.cpp
+    misc.cpp
+    taskmanager.cpp
+    processworker.cpp
 )
 
 set ( lxqt-admin-user_MOCS
@@ -18,6 +21,8 @@ set ( lxqt-admin-user_MOCS
     userdialog.h
     groupdialog.h
     usermanager.h
+    taskmanager.h
+    processworker.h
 )
 
 set( lxqt-admin-user_UIS

--- a/lxqt-admin-user/lxqt-admin-user-helper.default
+++ b/lxqt-admin-user/lxqt-admin-user-helper.default
@@ -6,6 +6,12 @@ useradd|usermod|userdel|groupadd|groupmod|groupdel|passwd|gpasswd)
     export LC_ALL=C
     exec "$@"
     ;;
+lxqt-admin-user-password)
+	export LD_LIBRARY_PATH=/usr/local/lib64
+	export PATH=$PATH:/usr/local/bin:
+	export QT_QPA_PLATFORMTHEME=lxqt
+	exec "$@"
+	;;
 *)
     echo "Command '$1' is not allowed!"
     exit 1

--- a/lxqt-admin-user/mainwindow.h
+++ b/lxqt-admin-user/mainwindow.h
@@ -23,6 +23,7 @@
 
 #include <QMainWindow>
 #include "ui_mainwindow.h"
+#include "taskmanager.h"
 
 class UserInfo;
 class GroupInfo;
@@ -46,9 +47,9 @@ public:
 private:
     UserInfo* userFromItem(QTreeWidgetItem* item);
     GroupInfo* groupFromItem(QTreeWidgetItem *item);
-    bool getNewPassword(const QString& name, QByteArray& passwd);
     void reloadUsers();
     void reloadGroups();
+    void lockWidget(bool lock);
 
 private Q_SLOTS:
     void onAdd();
@@ -57,6 +58,8 @@ private Q_SLOTS:
     void onChangePasswd();
     void reload();
     void onRowActivated(const QModelIndex& index);
+    void onCurrentTabChanged(int pos);
+    void onProcessing(TaskManager::State);
 
 private:
     Ui::MainWindow ui;

--- a/lxqt-admin-user/misc.cpp
+++ b/lxqt-admin-user/misc.cpp
@@ -1,0 +1,64 @@
+#include <QProcess>
+#include <QDebug>
+#include <QMessageBox>
+#include <LXQt/SingleApplication>
+#include "misc.h"
+#include "taskmanager.h"
+
+bool pkexec(const QStringList& command, const QByteArray& stdinData) {
+    Q_ASSERT(!command.isEmpty());
+    QProcess process;
+    qDebug() << command;
+    QStringList args;
+    args << QStringLiteral("--disable-internal-agent")
+         << QStringLiteral("lxqt-admin-user-helper")
+         << command;
+
+    process.start(QStringLiteral("pkexec"), args);
+    if(!stdinData.isEmpty()) {
+        process.waitForStarted();
+        process.write(stdinData);
+        process.waitForBytesWritten();
+        process.closeWriteChannel();
+    }
+
+    while (!process.waitForFinished(-1))
+        LXQt::Application::processEvents();
+
+    QByteArray pkexec_error = process.readAllStandardError();
+    qDebug() << pkexec_error;
+    const bool succeeded = process.exitCode() == 0;
+    if (!succeeded)
+    {
+        QMessageBox * msg = new QMessageBox{QMessageBox::Critical, QObject::tr("Error")
+            , QObject::tr("<strong>Action (%1) failed:</strong><br/><pre>%2</pre>").arg(command[0]).arg(QString::fromUtf8(pkexec_error.constData()))};
+        msg->setAttribute(Qt::WA_DeleteOnClose, true);
+        msg->show();
+    }
+    return succeeded;
+}
+
+bool pkexecGetOut(const QStringList &command, QString *out)
+{
+    Q_ASSERT(!command.isEmpty());
+    QProcess process;
+    qDebug() << command;
+    QStringList args;
+    args << QStringLiteral("--disable-internal-agent")
+        << QStringLiteral("lxqt-admin-user-helper")
+        << command;
+    process.start(QStringLiteral("pkexec"), args);
+    process.waitForFinished(-1);
+    if (out)
+        *out = QString::fromUtf8(process.readAllStandardOutput());
+    QByteArray pkexec_error = process.readAllStandardError();
+    const bool succeeded = process.exitCode() == 0;
+    if (!succeeded)
+    {
+        QMessageBox * msg = new QMessageBox{QMessageBox::Critical, QObject::tr("Error")
+            , QObject::tr("<strong>Action (%1) failed:</strong><br/><pre>%2</pre>").arg(command[0]).arg(QString::fromUtf8(pkexec_error.constData()))};
+        msg->setAttribute(Qt::WA_DeleteOnClose, true);
+        msg->show();
+    }
+    return succeeded;
+}

--- a/lxqt-admin-user/misc.h
+++ b/lxqt-admin-user/misc.h
@@ -1,0 +1,10 @@
+#ifndef MISC_H
+#define MISC_H
+
+#include <QStringList>
+
+bool pkexec(const QStringList& command, const QByteArray& stdinData = QByteArray());
+bool pkexecGetOut(const QStringList& command, QString *out);
+
+
+#endif // MISC_H

--- a/lxqt-admin-user/processworker.cpp
+++ b/lxqt-admin-user/processworker.cpp
@@ -1,0 +1,45 @@
+#include <QDebug>
+#include "processworker.h"
+
+
+Worker::Worker(QObject *parent)
+: QObject(parent)
+{
+    qRegisterMetaType<Worker::WorkerState>("Worker::WorkerState");
+}
+
+Worker::~Worker()
+{}
+
+/* *************************************************************************************** */
+
+ProcessWorker::ProcessWorker(const QString &cmd, const QStringList &args, QObject *parent)
+: Worker(parent),
+  mCmd(cmd),
+  mArgs(args),
+  mProcess(new QProcess(this))
+{
+    mProcess->setProcessChannelMode(QProcess::MergedChannels);
+
+    connect(mProcess,
+             static_cast<void(QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
+             [=] {
+        if (mProcess->exitCode() || (mProcess->exitStatus() != QProcess::NormalExit))
+            mState = FinishedWithError;
+        else
+            mState = Finished;
+        qDebug() << Q_FUNC_INFO << "cmd: " << cmd << " " << args << " ret: " << mState;
+        Q_EMIT notify(mState, QString::fromUtf8(mProcess->readAll()));
+        Q_EMIT finished();
+    } );
+}
+
+ProcessWorker::~ProcessWorker()
+{}
+
+void ProcessWorker::onRun()
+{
+    mProcess->start(mCmd, mArgs);
+    mState = Started;
+     Q_EMIT notify(mState);
+}

--- a/lxqt-admin-user/processworker.h
+++ b/lxqt-admin-user/processworker.h
@@ -1,0 +1,53 @@
+#ifndef PROCESSWORKER_H
+#define PROCESSWORKER_H
+
+#include <QObject>
+#include <QProcess>
+
+
+class Worker : public QObject
+{
+    Q_OBJECT
+public:
+    Worker(QObject *parent = 0);
+    ~Worker();
+
+    enum WorkerState
+    {
+        Undefined,
+        Started,
+        Finished,
+        FinishedWithError
+    };
+public slots:
+    virtual void onRun() = 0;
+
+signals:
+    void notify(Worker::WorkerState state, QString msg = QString());
+    void finished();
+
+protected:
+    WorkerState mState;
+};
+
+
+/* ********************************************************************************* */
+
+class ProcessWorker : public Worker
+{
+    Q_OBJECT
+public:
+    ProcessWorker(const QString &cmd, const QStringList &args, QObject *parent = 0);
+    ~ProcessWorker();
+
+public slots:
+    virtual void onRun();
+
+private:
+    QString mCmd;
+    QStringList mArgs;
+    QProcess *mProcess;
+    QStringList mResult;
+};
+
+#endif // PROCESSWORKER_H

--- a/lxqt-admin-user/taskmanager.cpp
+++ b/lxqt-admin-user/taskmanager.cpp
@@ -1,0 +1,84 @@
+#include <QDebug>
+#include <QThread>
+#include <QMessageBox>
+#include <QProgressBar>
+#include <QApplication>
+#include "taskmanager.h"
+
+TaskManager::TaskManager()
+{}
+
+TaskManager::~TaskManager()
+{}
+
+void TaskManager::execFirst()
+{
+    if (mWorkers.size())
+    {
+        Worker *worker = mWorkers.first();
+        mWorkers.pop_front();
+
+        QThread *thread = new QThread();
+        worker->moveToThread(thread);
+
+        connect(thread, SIGNAL(started()), worker, SLOT(onRun()));
+        connect(worker, SIGNAL(finished()), thread, SLOT(quit()));
+        connect(worker, SIGNAL(finished()), worker, SLOT(deleteLater()));
+        connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
+
+        connect(worker, SIGNAL(notify(Worker::WorkerState, QString)), this, SLOT(onWorkerStateChanged(Worker::WorkerState, QString)));
+        thread->start();
+    }
+    else
+        Q_EMIT stateChanged(TaskManager::Finished);
+}
+
+void TaskManager::onWorkerStateChanged(Worker::WorkerState state, QString msg)
+{
+    switch (state)
+    {
+        case ProcessWorker::Finished:
+        {
+            execFirst();
+        }
+        break;
+        case ProcessWorker::FinishedWithError:
+        {
+            mWorkers.clear();
+            QMessageBox::critical(mWidget,
+                                  QObject::tr("Error"),
+                                  msg);
+            Q_EMIT stateChanged(TaskManager::Finished);
+        }
+        break;
+        default:
+            break;
+    }
+}
+
+void TaskManager::run()
+{
+    if (mWorkers.size() == 0)
+        return;
+    Q_EMIT stateChanged(TaskManager::Processing);
+    execFirst();
+}
+
+void TaskManager::setWidget(const QWidget *widget)
+{
+    mWidget = (QWidget *) widget;
+}
+
+TaskManager *TaskManager::instance()
+{
+    if (mInstance == nullptr)
+        mInstance = new TaskManager;
+    return mInstance;
+}
+
+void TaskManager::append(const Worker *worker)
+{
+    mWorkers.append((Worker *) worker);
+}
+
+TaskManager* TaskManager::mInstance = nullptr;

--- a/lxqt-admin-user/taskmanager.h
+++ b/lxqt-admin-user/taskmanager.h
@@ -1,0 +1,43 @@
+#ifndef TASKMANAGER_H
+#define TASKMANAGER_H
+
+#include <QList>
+#include <QWidget>
+#include <QProgressDialog>
+#include "processworker.h"
+
+class TaskManager : public QObject
+{
+    Q_OBJECT
+public:
+    static TaskManager *instance();
+
+    void append(const Worker *worker);
+    void run();
+    void setWidget(const QWidget *widget);
+
+    enum State
+    {
+        Processing,
+        Finished
+    };
+
+signals:
+    void stateChanged(TaskManager::State);
+
+private:
+    TaskManager();
+    ~TaskManager();
+
+    void execFirst();
+
+private slots:
+    void onWorkerStateChanged(Worker::WorkerState, QString);
+
+private:
+    static TaskManager *mInstance;
+    QWidget *mWidget;
+    QList<Worker *> mWorkers;
+};
+
+#endif // TASKMANAGER_H

--- a/lxqt-admin-user/usermanager.h
+++ b/lxqt-admin-user/usermanager.h
@@ -200,12 +200,11 @@ public:
     bool addUser(UserInfo* user);
     bool modifyUser(UserInfo* user, UserInfo* newSettings);
     bool deleteUser(UserInfo* user);
-    bool changePassword(UserInfo* user, QByteArray newPasswd);
+    void changePassword(UserInfo* user);
 
     bool addGroup(GroupInfo* group);
     bool modifyGroup(GroupInfo* group, GroupInfo* newSettings);
     bool deleteGroup(GroupInfo* group);
-    bool changePassword(GroupInfo* group, QByteArray newPasswd);
 
     // FIXME: add APIs to change group membership with "gpasswd"
 
@@ -220,7 +219,6 @@ public:
 private:
     void loadUsersAndGroups();
     void loadLoginDefs();
-    bool pkexec(const QStringList &command, const QByteArray &stdinData = QByteArray());
 
 Q_SIGNALS:
     void changed();


### PR DESCRIPTION
Hi, 

Those patch adds new gui lxqt-admin-user-password utility, that can changes password for user.
This utility uses PAM stack for getting information from pam (messages like 'new password' in current user's locale), so can be useful as for lxqt-admin-user utility as for LXQt project.

Unfortunately, I have not any information how can change password for group via PAM stack.

I also use lxqt-admin-user-password for password changing from lxqt-admin-user utility. Any ideas are welcome.