### PR TITLE
Use local files for getting information about users and group

### DIFF
--- a/lxqt-admin-user/usermanager.cpp
+++ b/lxqt-admin-user/usermanager.cpp
@@ -61,9 +61,15 @@ void UserManager::loadUsersAndGroups()
     // if multiple sources are specified in nsswitch.conf(5).
 
     // load groups
-    setgrent();
+    FILE *fp = NULL;
+
+    if (!(fp = fopen(qPrintable(GROUP_FILE), "r")))
+    {
+        qWarning() << "Failed to open file " << GROUP_FILE << endl;
+        return;
+    }
     struct group * grp;
-    while((grp = getgrent())) {
+    while((grp = fgetgrent(fp))) {
         if (mGroups.cend() != std::find_if(mGroups.cbegin(), mGroups.cend(), [grp] (const GroupInfo * g) -> bool { return g->gid() == grp->gr_gid; }))
             continue;
         GroupInfo* group = new GroupInfo(grp);
@@ -73,15 +79,19 @@ void UserManager::loadUsersAndGroups()
             group->addMember(QString::fromLatin1(*member_name));
         }
     }
-    endgrent();
+    fclose(fp);
     std::sort(mGroups.begin(), mGroups.end(), [](GroupInfo* g1, GroupInfo* g2) {
         return g1->name() < g2->name();
     });
 
     // load users
-    setpwent();
+    if (!(fp = fopen(qPrintable(PASSWD_FILE), "r")))
+    {
+        qWarning() << "Failed to open file " << PASSWD_FILE << endl;
+        return;
+    }
     struct passwd * pw;
-    while((pw = getpwent())) {
+    while((pw = fgetpwent(fp))) {
         if (mUsers.cend() != std::find_if(mUsers.cbegin(), mUsers.cend(), [pw] (const UserInfo * u) -> bool { return u->uid() == pw->pw_uid; }))
             continue;
         UserInfo* user = new UserInfo(pw);
@@ -93,7 +103,7 @@ void UserManager::loadUsersAndGroups()
             }
         }
     }
-    endpwent();
+    fclose(fp);
     std::sort(mUsers.begin(), mUsers.end(), [](UserInfo*& u1, UserInfo*& u2) {
         return u1->name() < u2->name();
     });


### PR DESCRIPTION
Hi,

Because getgrent() and getpwent() calls uses NSS for all available users and groups on machine (includes non-local). So, those patch uses only local /etc/passwd and /etc/groups files for getting information about uses and groups.