### PR TITLE
ui: small tweaks

### DIFF
--- a/lxqt-admin-user/mainwindow.ui
+++ b/lxqt-admin-user/mainwindow.ui
@@ -10,7 +10,7 @@
     <height>362</height>
    </rect>
   </property>
-  <property name="windowTitle">
+  <property name="UserGroupSettingsWindow">
    <string>User and Group Settings</string>
   </property>
   <widget class="QWidget" name="centralwidget">
@@ -130,9 +130,6 @@
    </layout>
   </widget>
   <widget class="QToolBar" name="toolBar">
-   <property name="windowTitle">
-    <string>toolBar</string>
-   </property>
    <property name="movable">
     <bool>false</bool>
    </property>
@@ -185,7 +182,7 @@
     <string>Properties</string>
    </property>
    <property name="toolTip">
-    <string>edit properties of the selected item</string>
+    <string>Edit properties of the selected item</string>
    </property>
   </action>
   <action name="actionRefresh">


### PR DESCRIPTION
- set a name attribute to a non-trivial value
- remove unused "toolBar" name
- fix a capitalisation typo in a tooltip