### PR TITLE
ui: small tweaks rev-2

### DIFF
--- a/lxqt-admin-user/mainwindow.ui
+++ b/lxqt-admin-user/mainwindow.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>MainWindow</class>
- <widget class="QMainWindow" name="MainWindow">
+ <widget class="QMainWindow" name="UserGroupSettingsWindow">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -130,9 +130,6 @@
    </layout>
   </widget>
   <widget class="QToolBar" name="toolBar">
-   <property name="windowTitle">
-    <string>toolBar</string>
-   </property>
    <property name="movable">
     <bool>false</bool>
    </property>
@@ -185,7 +182,7 @@
     <string>Properties</string>
    </property>
    <property name="toolTip">
-    <string>edit properties of the selected item</string>
+    <string>Edit properties of the selected item</string>
    </property>
   </action>
   <action name="actionRefresh">


### PR DESCRIPTION
- set a name attribute to a non-trivial value
- remove unused "toolBar" name
- fix a capitalisation typo in a tooltip

Note: This is actually a fixup to @807b9e1

A fix up to PR #134, reverted in issue #140.