### PR TITLE
ui: avoid creating a popup menu for toolbar

### DIFF
--- a/lxqt-admin-user/mainwindow.ui
+++ b/lxqt-admin-user/mainwindow.ui
@@ -10,6 +10,9 @@
     <height>362</height>
    </rect>
   </property>
+  <property name="contextMenuPolicy">
+   <enum>Qt::NoContextMenu</enum>
+  </property>
   <property name="windowTitle">
    <string>User and Group Settings</string>
   </property>


### PR DESCRIPTION
As default QMainWindow creates a popup menu which enables user to hide a
toolbar, but as for lxqt-admin-user it breaks ui to a bearly-usable
state, so avoid creating the menu.