### PR TITLE
Fix the desktop translation for cs to make it valid

### DIFF
--- a/lxqt-admin-time/translations/lxqt-admin-time_cs.desktop
+++ b/lxqt-admin-time/translations/lxqt-admin-time_cs.desktop
@@ -1,4 +1,4 @@
 #TRANSLATIONS
 Name[cs]=Datum a čas
 GenericName[cs]=Nastavení data a času
-Comment [cs]=Nastavení systémového data a času
+Comment[cs]=Nastavení systémového data a času

--- a/lxqt-admin-user/translations/lxqt-admin-user_cs.desktop
+++ b/lxqt-admin-user/translations/lxqt-admin-user_cs.desktop
@@ -1,4 +1,4 @@
 #TRANSLATIONS
-Name [cs]=Uživatelé a skupiny
+Name[cs]=Uživatelé a skupiny
 GenericName[cs]=Nastavení uživatelů a skupin
 Comment[cs]=Nastavení uživatelů a skupin systému


### PR DESCRIPTION
With a space after the key Name, desktop file validate failed in Fedora
packaging.

Signed-off-by: Zamir SUN <sztsian@gmail.com>