### PR TITLE
Replace generic window icons to match .desktop icons

### DIFF
--- a/lxqt-admin-time/main.cpp
+++ b/lxqt-admin-time/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
     parser.process(app);
 
     TimeAdminDialog dlg;
-    dlg.setWindowIcon(QIcon::fromTheme(QSL("preferences-system")));
+    dlg.setWindowIcon(QIcon::fromTheme(QSL("preferences-system-time")));
     app.setActivationWindow(&dlg);
     dlg.show();
     return app.exec();

--- a/lxqt-admin-user/main.cpp
+++ b/lxqt-admin-user/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
     parser.process(app);
 
     MainWindow window;
-    window.setWindowIcon(QIcon::fromTheme(QSL("preferences-system")));
+    window.setWindowIcon(QIcon::fromTheme(QSL("system-users")));
     app.setActivationWindow(&window);
     window.show();
     return app.exec();


### PR DESCRIPTION
For Users/Groups and Time/Date, 'preferences-system' replaced with 'system-users' and 'preferences-system-time'.