### PR TITLE
Set /bin/bash default shell if available

### DIFF
--- a/lxqt-admin-user/usermanager.cpp
+++ b/lxqt-admin-user/usermanager.cpp
@@ -436,11 +436,17 @@ const QStringList& UserManager::availableShells() {
                 QByteArray line = file.readLine().trimmed();
                 if(line.isEmpty() || line.startsWith('#'))
                     continue;
-                mAvailableShells.append(QString::fromLocal8Bit(line));
+                QString shell = QString::fromLocal8Bit(line);
+                 if (shell.endsWith(QLatin1String("/bash")) ) {
+                    mAvailableShells.prepend(shell);
+                } else {
+                    mAvailableShells.append(shell);
+                }
             }
             file.close();
         }
     }
     return mAvailableShells;
 }
+
 


### PR DESCRIPTION
Fixes https://github.com/lxqt/lxqt-admin/issues/259

Tested also with `#/bin/bash` commented out in `/etc/shells` (don't shutdown with that...)


![screen_area_dom_12:38:55_](https://github.com/lxqt/lxqt-admin/assets/10681413/8b32b322-b71f-45fe-b283-618ab600ccd1)

![screen_area_dom_12:38:39_](https://github.com/lxqt/lxqt-admin/assets/10681413/01db254b-44cd-4824-98a4-82b7d93a0d22)


