### PR TITLE
Remove KWindowSystem as direct dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,11 @@ option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" O
 set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}" CACHE PATH "Installation path for libraries")
 
 # Minimum Versions
-set(KF5_MINIMUM_VERSION "5.36.0")
 set(LXQT_MINIMUM_VERSION "1.3.0")
 set(QT_MINIMUM_VERSION "5.15.0")
 
 find_package(Qt5Widgets ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt ${LXQT_MINIMUM_VERSION} REQUIRED)
-find_package(KF5WindowSystem ${KF5_MINIMUM_VERSION} REQUIRED)
 find_package(PolkitQt5-1 REQUIRED)
 
 # Patch Version

--- a/lxqt-admin-time/CMakeLists.txt
+++ b/lxqt-admin-time/CMakeLists.txt
@@ -75,7 +75,6 @@ add_executable(lxqt-admin-time
 )
 
 target_link_libraries(lxqt-admin-time
-    KF5::WindowSystem
     Qt5::Widgets
     Qt5::DBus
     lxqt

--- a/lxqt-admin-user/CMakeLists.txt
+++ b/lxqt-admin-user/CMakeLists.txt
@@ -58,7 +58,6 @@ add_executable(lxqt-admin-user
 )
 
 target_link_libraries(lxqt-admin-user
-    KF5::WindowSystem
     Qt5::Widgets
     lxqt
 )


### PR DESCRIPTION
KWindowSystem isn't an source code dependency.
liblxqt brings KWindowSystem in as an INTERFACE_LINK dependency.
