### PR TITLE
Show user and groups settings under "System"

### DIFF
--- a/lxqt-admin-user/lxqt-admin-user.desktop.in
+++ b/lxqt-admin-user/lxqt-admin-user.desktop.in
@@ -2,7 +2,7 @@
 Type=Application
 Exec=lxqt-admin-user
 Icon=system-users
-Categories=LXQt;Settings;DesktopSettings;Qt;
+Categories=Settings;DesktopSettings;Qt;System;
 OnlyShowIn=LXQt;
 
 #TRANSLATIONS_DIR=translations


### PR DESCRIPTION
I retry. The correct place is "System".
```
Desktop Entry/Name: "Users and Groups"
Desktop Entry/GenericName: "User and Group Settings"
Desktop Entry/Comment: "Configure the users and groups of your system"
```