### PR TITLE
lxqt-admin-user: Set window title for dialog

### DIFF
--- a/lxqt-admin-user/mainwindow.cpp
+++ b/lxqt-admin-user/mainwindow.cpp
@@ -148,7 +148,6 @@ void MainWindow::onAdd()
     {
         UserInfo newUser;
         UserDialog dlg(mUserManager, &newUser, this);
-        dlg.setWindowTitle(tr("Add User"));
         if(dlg.exec() == QDialog::Accepted)
         {
             mUserManager->addUser(&newUser);
@@ -162,7 +161,6 @@ void MainWindow::onAdd()
     {
         GroupInfo newGroup;
         GroupDialog dlg(mUserManager, &newGroup, this);
-        dlg.setWindowTitle(tr("Add Group"));
         if(dlg.exec() == QDialog::Accepted)
         {
             mUserManager->addGroup(&newGroup);

--- a/lxqt-admin-user/mainwindow.cpp
+++ b/lxqt-admin-user/mainwindow.cpp
@@ -148,6 +148,7 @@ void MainWindow::onAdd()
     {
         UserInfo newUser;
         UserDialog dlg(mUserManager, &newUser, this);
+        dlg.setWindowTitle(tr("Add User"));
         if(dlg.exec() == QDialog::Accepted)
         {
             mUserManager->addUser(&newUser);
@@ -161,6 +162,7 @@ void MainWindow::onAdd()
     {
         GroupInfo newGroup;
         GroupDialog dlg(mUserManager, &newGroup, this);
+        dlg.setWindowTitle(tr("Add Group"));
         if(dlg.exec() == QDialog::Accepted)
         {
             mUserManager->addGroup(&newGroup);
@@ -198,6 +200,7 @@ void MainWindow::onDelete()
 
 bool MainWindow::getNewPassword(const QString& name, QByteArray& passwd) {
     QInputDialog dlg(this);
+    dlg.setWindowTitle(tr("Change Password"));
     dlg.setTextEchoMode(QLineEdit::Password);
     dlg.setLabelText(tr("Input the new password for %1:").arg(name));
     QLineEdit* edit = dlg.findChild<QLineEdit*>(QString());


### PR DESCRIPTION
1. Set (previously null) title for the password dialog to "Change Password". That string is already translated and theoretically can be reused.
2. _Add_ user uses the same dialog as _Properties_, but the title under "Add" ("User Settings") doesn't match the intent. Set to "Add User".
3. Same as (2) but for groups -- "Add Group".