### PR TITLE
Add ability to see main members in groups

### DIFF
--- a/lxqt-admin-user/groupdialog.cpp
+++ b/lxqt-admin-user/groupdialog.cpp
@@ -26,7 +26,7 @@
 #define DEFAULT_GID_MIN 1000
 #define DEFAULT_GID_MAX 32768
 
-GroupDialog::GroupDialog(UserManager* userManager, GroupInfo* group, QWidget *parent, Qt::WindowFlags f):
+GroupDialog::GroupDialog(bool addDialog, UserManager* userManager, GroupInfo* group, QWidget *parent, Qt::WindowFlags f):
     QDialog(parent, f),
     mUserManager(userManager),
     mGroup(group)
@@ -34,6 +34,13 @@ GroupDialog::GroupDialog(UserManager* userManager, GroupInfo* group, QWidget *pa
     ui.setupUi(this);
     ui.groupName->setText(group->name());
     ui.gid->setValue(group->gid());
+
+    // gray out main members wigde
+    if (addDialog)
+    {
+        ui.mainUserLabel->hide();
+        ui.mainUserList->hide();
+    }
 
     const QStringList& members = group->members(); // all users in this group
     // load all users
@@ -49,6 +56,16 @@ GroupDialog::GroupDialog(UserManager* userManager, GroupInfo* group, QWidget *pa
         QVariant obj = QVariant::fromValue<void*>((void*)user);
         item->setData(Qt::UserRole, obj);
         ui.userList->addItem(item);
+
+        // Check if user's gid is this group
+        if(!addDialog && user->gid() == group->gid())
+        {
+            QListWidgetItem* mainUserItem = new QListWidgetItem();
+            mainUserItem->setText(user->name());
+            mainUserItem->setFlags(Qt::ItemIsEnabled);
+            mainUserItem->setData(Qt::UserRole, obj);
+            ui.mainUserList->addItem(mainUserItem);
+        }
     }
 }
 

--- a/lxqt-admin-user/groupdialog.h
+++ b/lxqt-admin-user/groupdialog.h
@@ -32,7 +32,7 @@ class GroupDialog : public QDialog
     Q_OBJECT
 
 public:
-    GroupDialog(UserManager* userManager, GroupInfo* group, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+    GroupDialog(bool addDialog, UserManager* userManager, GroupInfo* group, QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
     ~GroupDialog();
 
     virtual void accept();

--- a/lxqt-admin-user/groupdialog.ui
+++ b/lxqt-admin-user/groupdialog.ui
@@ -13,52 +13,74 @@
   <property name="windowTitle">
    <string>Group Settings</string>
   </property>
-  <layout class="QFormLayout" name="formLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Group name:</string>
-     </property>
-    </widget>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Group ID:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Group name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QSpinBox" name="gid">
+       <property name="specialValueText">
+        <string>Default</string>
+       </property>
+       <property name="maximum">
+        <number>32768</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="groupName"/>
+     </item>
+    </layout>
    </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="groupName"/>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="0">
+      <widget class="QListWidget" name="userList">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Users belong to this group:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="mainUserLabel">
+       <property name="text">
+        <string>Main members:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QListWidget" name="mainUserList">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
-   <item row="1" column="1">
-    <widget class="QSpinBox" name="gid">
-     <property name="specialValueText">
-      <string>Default</string>
-     </property>
-     <property name="maximum">
-      <number>32768</number>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Group ID:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Users belong to this group:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QListWidget" name="userList">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>1</verstretch>
-      </sizepolicy>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/lxqt-admin-user/mainwindow.cpp
+++ b/lxqt-admin-user/mainwindow.cpp
@@ -110,7 +110,8 @@ void MainWindow::reloadGroups()
         QVariant obj = QVariant::fromValue<void*>((void*)group);
         item->setData(0, Qt::UserRole, obj);
         item->setData(1, Qt::DisplayRole, group->gid());
-        item->setData(2, Qt::DisplayRole, group->members().join(QL1S(", ")));
+        item->setData(2, Qt::DisplayRole, group->mainMembers().join(QL1S(", ")));
+        item->setData(3, Qt::DisplayRole, group->members().join(QL1S(", ")));
         items.append(item);
     }
     ui.groupList->clear();
@@ -160,7 +161,7 @@ void MainWindow::onAdd()
     else if (ui.tabWidget->currentIndex() == PageGroups)
     {
         GroupInfo newGroup;
-        GroupDialog dlg(mUserManager, &newGroup, this);
+        GroupDialog dlg(true, mUserManager, &newGroup, this);
         if(dlg.exec() == QDialog::Accepted)
         {
             mUserManager->addGroup(&newGroup);
@@ -278,7 +279,7 @@ void MainWindow::onEditProperties()
         GroupInfo* group = groupFromItem(item);
         if(group) {
             GroupInfo newSettings(*group);
-            GroupDialog dlg(mUserManager, &newSettings, this);
+            GroupDialog dlg(false, mUserManager, &newSettings, this);
             if(dlg.exec() == QDialog::Accepted)
             {
                 mUserManager->modifyGroup(group, &newSettings);

--- a/lxqt-admin-user/mainwindow.ui
+++ b/lxqt-admin-user/mainwindow.ui
@@ -118,6 +118,11 @@
           </column>
           <column>
            <property name="text">
+            <string>Main Members</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
             <string>Members</string>
            </property>
           </column>

--- a/lxqt-admin-user/translations/lxqt-admin-user.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user.ts
@@ -9,32 +9,37 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_ar.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_ar.ts
@@ -9,32 +9,37 @@
         <translation>إعدادات المجموعة</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>اسم المجموعة:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>المبدئي</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>معرّف المجموعة:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>المستخدمون في هذه المجموعة:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>خطأ</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>لا يمكن ترك اسم المجموعة فارغا.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>الأعضاء</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>تحرير خصائص العنصر المحدد</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>أضِف</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>أضِف مستخدمين أو مجموعات جديدة</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>احذف</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>احذف العنصر المحدد</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>الخصائص</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>أنعِش</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>أنعِش القوائم</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>غيّر كلمة السر</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>غيّر كلمة سر المستخدم أو المجموعة المحددة</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>تأكيد</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>أمتأكد من حذف المستخدم المحدد؟</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>أمتأكد من حذف المجموعة المحددة؟</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>أدخِل كلمة سر ⁨%1⁩ الجديدة:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>أمتأكد من ضبط كلمة سر فارغة؟</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;فشل الإجراء (%1):&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_arn.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_arn.ts
@@ -9,32 +9,37 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_ast.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_ast.ts
@@ -9,32 +9,37 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_bg.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_bg.ts
@@ -9,32 +9,37 @@
         <translation>Настройки на група</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Име на група:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>По подразбиране</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Потребители в групата:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Грешка</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Името на групата не може да бъде празно.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Членове</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Редактиране на свойствата на избрания елемент</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Добавяне</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Добавяне на нов потребител и група</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Изтриване</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Изтриване на избрания елемент</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Опресняване</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Опресняване на списъка</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Смяна на парола</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Смяна на парола на избрания потребител и група</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Потвърждаване</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Сигурни ли сте, че искате да изтриете избрания потребител?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Сигурни ли сте, че искате да изтриете избраната група?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Въведете нова парола за %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Сигурни ли сте, че искате да зададете празна парола?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Действие (%1) неуспешно:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_ca.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_ca.ts
@@ -9,32 +9,37 @@
         <translation>Ajusts del grup</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Nom del grup:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Predeterminat</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Id. de grup:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Usuaris que pertanyen a aquest grup:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>El nom del grup no pot estar en blanc.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Membres</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Edita les propietats de l&apos;element seleccionat</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Afegeix</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Afegeix nous usuaris o grups</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Suprimeix</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Suprimeix l&apos;ítem seleccionat</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Propietats</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Refresca</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Refresca els llistats</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Canvia la contrasenya</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Canvia la contrasenya per als usuaris o grups seleccionats</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Confirma</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Esteu segur que voleu suprimir l&apos;usuari seleccionat?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Esteu segur que voleu suprimir el grup seleccionat?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Introduïu la nova contrasenya per a %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Esteu segur que voleu establir una contrasenya buida?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Ha fallat l&apos;acció (%1):&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_cs.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_cs.ts
@@ -9,32 +9,37 @@
         <translation>Nastavení skupiny</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Název skupiny:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Výchozí</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Identif. skupiny:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Uživatelé, kteří jsou členy této skupiny:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Název skupiny nemůže zůstat nevyplněný.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Členové</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Upravit vlastnosti označené položky</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Přidat</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Přidat nové uživatele a skupiny</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Smazat vybranou položku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Vlastnosti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Načíst znovu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Znovunačíst seznam</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Změnit heslo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Změnit heslo pro vybraného uživatele nebo skupinu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Potvrdit</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Opravdu chcete vybraného uživatele smazat?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Opravdu chcete vybranou skupinu smazat?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Zadejte nové heslo pro %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Opravdu chcete nastavit bez hesla?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Akce (%1) se nezdařila:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_cy.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_cy.ts
@@ -9,32 +9,37 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation></translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation></translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation></translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_da.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_da.ts
@@ -31,7 +31,7 @@
     <message>
         <location filename="../groupdialog.ui" line="70"/>
         <source>Main members:</source>
-        <translation type="unfinished"></translation>
+        <translation>Hovedmedlemmer:</translation>
     </message>
     <message>
         <location filename="../groupdialog.cpp" line="81"/>
@@ -104,7 +104,7 @@
     <message>
         <location filename="../mainwindow.ui" line="121"/>
         <source>Main Members</source>
-        <translation type="unfinished"></translation>
+        <translation>Hovedmedlemmer</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="126"/>

--- a/lxqt-admin-user/translations/lxqt-admin-user_da.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_da.ts
@@ -9,32 +9,37 @@
         <translation>Gruppeindstillinger</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Gruppenavn:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Gruppe-ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Brugere tilhører denne gruppe:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Fejl</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Gruppenavnet må ikke være tomt.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Medlemmer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Rediger egenskaber for den valgte post</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Tilføj</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Tilføj nye brugere eller grupper</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Slet valgte post</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Egenskaber</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Opdater</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Opdater listerne</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Skift adgangskode</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Skift adgangskode for den valgte bruger eller gruppe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Bekræft</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Er du sikker på, at du vil slette den valgte bruger?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Er du sikker på, at du vil slette den valgte gruppe?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Input den nye adgangskode til %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Er du sikker på, at du vil sætte en tom adgangskode?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Handling (%1) mislykkedes:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_de.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_de.ts
@@ -9,32 +9,37 @@
         <translation>Gruppeneinstellungen</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Gruppenname:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Gruppen-ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Benutzer in dieser Gruppe:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Der Gruppenname darf nicht leer sein.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Mitglieder</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Bearbeiten der Eigenschaften des ausgewählten Elements</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Neue Benutzer oder Gruppen hinzufügen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Ausgewähltes Element löschen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Erneuern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Listen erneuern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Passwort ändern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Passwort für den ausgewählten Benutzer oder die ausgewählte Gruppe ändern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Bestätigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Sind Sie sicher, dass Sie den ausgewählten Benutzer löschen möchten?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Sind Sie sicher, dass Sie die ausgewählte Gruppe löschen möchten?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Geben Sie das neue Passwort für %1 ein:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Sind Sie sicher, dass Sie ein leeres Passwort festlegen möchten?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Aktion (%1) fehlgeschlagen:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_el.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_el.ts
@@ -9,32 +9,37 @@
         <translation>Ρυθμίσεις ομάδας</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Όνομα ομάδας:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Αναγνωριστικό ομάδας:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Χρήστες που ανήκουν στην ομάδα:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Το όνομα της ομάδας δεν μπορεί να είναι κενό.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Μέλη</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Επεξεργασία των ιδιοτήτων για το επιλεγμένο αντικείμενο</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Προσθήκη</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Προσθήκη νέων χρηστών ή ομάδων</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Διαγραφή του επιλεγμένου αντικειμένου</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Ιδιότητες</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Ανανέωση</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Ανανέωση της λίστας</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Αλλαγή του κωδικού πρόσβασης</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Αλλαγή του κωδικού πρόσβασης του επιλεγμένου χρήστη ή ομάδος</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Επιβεβαίωση</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Είστε σίγουρος-η ότι θέλετε να διαγράψετε τον επιλεγμένο χρήστη;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Είστε σίγουρος-η ότι θέλετε να διαγράψετε την επιλεγμένη ομάδα;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Εισαγάγετε τον νέο κωδικό πρόσβασης για τον χρήστη %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Επιθυμείτε πραγματικά τον ορισμό ενός κενού κωδικού πρόσβασης;</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Η ενέργεια (%1) απέτυχε:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_en_GB.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_en_GB.ts
@@ -9,32 +9,37 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation></translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Are you sure you want to set an empty password?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation></translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_es.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_es.ts
@@ -9,32 +9,37 @@
         <translation>Configuración de grupos</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Nombre del grupo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Por omisión</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ID del grupo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Los usuarios pertenecen a este grupo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>El nombre del grupo no puede estar vacío.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Miembros</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Editar las propiedades del elemento seleccionado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Añadir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Añadir nuevos usuarios o grupos</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Borrar el elemento seleccionado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Actualizar la lista</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Cambiar la contraseña</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Cambiar la contraseña del usuario o grupo seleccionado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>¿Seguro que quiere borrar el usuario seleccionado?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>¿Seguro que quiere borrar el grupo seleccionado?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Introduzca la contraseña nueva para %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>¿Seguro que quiere usar una contraseña vacía?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Acción (%1) fallida:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_et.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_et.ts
@@ -9,32 +9,37 @@
         <translation>Gruppide seadistused</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Grupi nimi:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Lase süsteemil valida</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Grupi ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Kasutajad, kes kuuluvad siia gruppi:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Viga</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Grupil peab olema nimi.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Liikmed</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Muuda valitud kirje omadusi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Lisa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Lisa uusi kasutajaid või kasutajagruppe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Kustuta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Kustuta valitud kirje</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Omadused</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Värskenda</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Värskenda loendid</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Muuda salasõna</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Muuda valitud kasutaja või grupi salasõna</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Kinnita</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Kas sa oled kindel, et soovid selle kasutaja kustutada?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Kas sa oled kindel, et soovid selle grupi kustutada?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Sisesta %1 uus salasõna:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Kas sa oled kindel, et soovid sisestada olematut salasõna?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Toiming (%1) ei õnnestunud:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_fi.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_fi.ts
@@ -9,32 +9,37 @@
         <translation>Ryhmän asetukset</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Ryhmän nimi:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Oletus</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Ryhmätunniste:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Ryhmään kuuluvat käyttäjät:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Ryhmän nimi ei voi olla tyhjä.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Jäsenet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Muokkaa valitun kohteen ominaisuuksia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Lisää</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Lisää uusia käyttäjiä tai ryhmiä</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Poista valittu kohde</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Ominaisuudet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Päivitä</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Päivitä luettelot</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Vaihda salasana</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Vaihda valitun käyttäjän tai ryhmän salasana</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Kyllä</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Haluatko varmasti poistaa valitun käyttäjän?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Haluatko varmasti poistaa valitun ryhmän?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Uusi salasana (%1):</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Haluatko varmasti asettaa tyhjän salasanan?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;-Toiminto (%1) epäonnistui:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_fr.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_fr.ts
@@ -9,32 +9,37 @@
         <translation>Paramètres du groupe</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Nom du groupe :</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Par défaut</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Identifiant du groupe :</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Utilisateurs de ce groupe :</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Le nom du groupe ne peut pas être vide.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Membres</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Modifier les propriétés de l&apos;élément sélectionné</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Ajouter de nouveaux utilisateurs ou groupes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Supprimer l&apos;élément sélectionné</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Propriétés</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Rafraîchir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Actualiser les listes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Changer le mot de passe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Changer le mot de passe pour l&apos;utilisateur ou le groupe sélectionné</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Confirmer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Êtes-vous sûr de vouloir supprimer l&apos;utilisateur sélectionné ?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Êtes-vous sûr de vouloir supprimer le groupe sélectionné ?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Saisir le nouveau mot de passe pour %1 :</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Êtes-vous sûr de vouloir définir un mot de passe vide ?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;L&apos;action (%1) a échoué:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_gl.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_gl.ts
@@ -9,32 +9,37 @@
         <translation>Axustes do grupo</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Nome do grupo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Predeterminado</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ID do grupo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Usuarios que pertencen a este grupo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>O nome do grupo non pode estar baleiro.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Membros</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Editar as propiedades do elemento seleccionado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Engadir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Engadir novos usuarios ou grupos</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Eliminar o elemento seleccionado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Actualizar as listas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Cambiar o contrasinal</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Cambiar o contrasinal do usuario ou grupo seleccionado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Confirma que quere eliminar o usuario seleccionado?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Confirma que quere eliminar o grupo seleccionado?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Introduza o novo contrasinal para %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Confirma que quere empregar un contrasinal baleiro?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Produciuse un fallo na acción (%1):&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_he.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_he.ts
@@ -9,32 +9,37 @@
         <translation>הגדרות קבוצה</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>שם קבוצה:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>בררת מחדל</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>מזהה קבוצה:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>משתמשים ששייכים לקבוצה הזו:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>שגיאה</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>שם הקבוצה לא יכול להישאר ריק.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>חברים</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>עריכת מאפייני הפריט הנבחר</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>הוספה</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>הוספת משתמשים או קבוצות חדשים</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>מחיקה</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>מחיקת הפריט הנבחר</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>מאפיינים</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>רענון</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>רענון הרשימות</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>החלפת ססמה</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>החלפת הססמה למשתמש או לקבוצה הנבחרים</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>אישור</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>למחוק את המשתמש הנבחר?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>למחוק את הקבוצה הנבחרת?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>הקלדת הססמה החדשה עבור %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>להגדיר ססמה ריקה?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;הפעולה (%1) נכשלה:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_hi.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_hi.ts
@@ -9,32 +9,37 @@
         <translation>ग्रुप सेटिंग</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>ग्रुप का नाम :</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>आरंभिक</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ग्रुप ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>उपयोगकर्ता इस समूह से संबंधित हैं :</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>त्रुटि</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>समूह का नाम रिक्त नहीं रह सकता.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>सदस्यगण</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>चयनित आइटम के गुण संपादित करें</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>जोड़ें</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>नए उपयोगकर्ता या समूह जोड़ें</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>हटाएँ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>चयनित आइटम हटाएं</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>गुण</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>रीफ़्रेश करें</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>सूचियों को रीफ़्रेश करें</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>पासवर्ड बदलें</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>चयनित उपयोगकर्ता या समूह के लिए पासवर्ड बदलें</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>पुष्टि करें</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>क्या आप चुने गए उपयोगकर्ता को हटाना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>क्या आप चयनित समूह को हटाना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>%1 के लिए नया पासवर्ड डालें :</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>क्या आप एक रिक्त पासवर्ड सेट करना चाहते हैं?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;एक्शन (%1) विफल :&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_hr.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_hr.ts
@@ -9,32 +9,37 @@
         <translation>Postavke grupe</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Ime grupe:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Standardno</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ID grupe:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Korisnici koji pripadaju ovoj grupi:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Greška</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Ime grupe ne može biti prazno.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Članovi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Uredi svojstva odabrane stavke</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Dodaj</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Dodaj nove korisnike ili grupe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Izbriši</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Izbriši odabranu stavku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Svojstva</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Aktualiziraj</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Aktualiziraj popise</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Promijeni lozinku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Promijeni lozinku za odabrnog korisnika ili grupu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Potvrdi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Stvarno želiš izbrisati odabranoga korisnika?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Stvarno želiš izbrisati odabranu grupu?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Upiši novu lozinku za %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Stvarno želiš postaviti praznu lozinku?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Radnja (%1) neuspjela:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_hu.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_hu.ts
@@ -9,32 +9,37 @@
         <translation>Csoportbeállítások</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Csoportnév:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Alapértelmezett</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Csoport ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>A csoport tagjai:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>A csoport neve nem lehet üres.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Tagok</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Kiválasztott elem tulajdonságainak szerkesztése</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Hozzáadás</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Új felhasználó, vagy csoport hozzáadása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Kiválasztott elem törlése</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Tulajdonságok</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Frissítés</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Listák frissítése</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Jelszó módosítása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Felhasználó, vagy csoport jelszavának megváltoztatása</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Megerősítés</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Biztosan törli a kiválasztott felhasználót?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Biztosan törli a kiválasztott csoportot?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Adja meg %1 új jelszavát:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Biztos benne, hogy üres legyen a jelszó?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;A (%1) művelet sikertelen:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_id.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_id.ts
@@ -9,32 +9,37 @@
         <translation>Pengaturan Grup</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Nama grup:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Baku</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ID Grup:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Pengguna termasuk dalam grup ini:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Kesalahan</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Nama grup tidak boleh kosong.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Anggota</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Edit properti dari item yang dipilih</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Tambah</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Tambah pengguna atau grup baru</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Hapus</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Hapus item terpilih</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Properti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Segarkan</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Segarkan daftar ini</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Ubah Kata Sandi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Ubah kata sandi untuk pengguna atau grup yang terpilih</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Konfirmasi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Apakah Anda yakin ingin menghapus pengguna yang terpilih?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Apakah Anda yakin ingin menghapus grup yang terpilih?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Masukkan kata sandi baru untuk %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Apakah Anda yakin ingin menetapkan kata sandi kosong?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Aksi (%1) gagal:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_it.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_it.ts
@@ -9,32 +9,37 @@
         <translation>Impostazioni gruppi</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Nome del gruppo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ID gruppo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Utenti appartenenti al gruppo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Il nome del gruppo non può essere vuoto.</translation>
     </message>
@@ -98,85 +103,90 @@
         <translation>ID gruppo</translation>
     </message>
     <message>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <location filename="../mainwindow.ui" line="121"/>
         <source>Members</source>
         <translation>Membri</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Modifica le proprietà dell&apos;oggetto selezionato</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Aggiungi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Aggiungi nuovi utenti o gruppi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Elimina l&apos;elemento selezionato</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Proprietà</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Aggiorna l&apos;elenco</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Cambia password</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Cambia password per l&apos;utente o il gruppo selezionato</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Si è sicuro di voler eliminare l&apos;utente selezionato?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Si è sicuro di voler eliminare il gruppo selezionato?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Immetti il nuovo password per %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Si è sicuro ti impostare un password vuoto?</translation>
     </message>
@@ -257,7 +267,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Azione (%1) fallita:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_ja.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_ja.ts
@@ -9,32 +9,37 @@
         <translation>グループ設定</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>グループ名:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>既定</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>グループ ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>このグループに属しているユーザー:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>グループ名を入力する必要があります。</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>メンバー</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>選択したアイテムのプロパティを編集します</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>追加</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>新しいユーザーやグループを追加します</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>選択したアイテムを削除します</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>プロパティ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>再読込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>リストを再読込みします</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>パスワードの変更</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>選択したユーザーやグループのパスワードを変更します</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>本当に選択したユーザーを削除しますか？</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>本当に選択したグループを削除しますか？</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>%1 の新しいパスワードを入力して下さい:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>パスワードを空にしますか？</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;アクション(%1)が失敗:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_ka.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_ka.ts
@@ -9,32 +9,37 @@
         <translation>ჯგუფის მორგება</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>ჯგუფის სახელი:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>ნაგულისხმევი</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ჯგუფის ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>მომხმარებლები ამ ჯგუფში:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>შეცდომა</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>ჯგუფის სახელი ცარიელი ვერ იქნება.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>წევრები</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>მონიშნული ელემენტის თვისებების ჩასწორება</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>დამატება</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>ახალი მომხმარებლებისა და ჯგუფების დამატება</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>წაშლა</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>მონიშნული ელემენტის წაშლა</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>თვისებები</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>განახლება</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>სიების განახლება</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>პაროლის შეცვლა</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>პაროლის შეცვლა მონიშნული მომხმარებლისთვის ან ჯგუფისთვის</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>დადასტურება</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>მართლა გნებავთ მონიშნული მომხმარებლის წაშლა?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>მართლა გნებავთ მონიშნული ჯგუფის წაშლა?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>შეიყვანეთ პაროლი %1-სთვის:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>მართლა გნებავთ, ცარიელი პაროლი დააყენოთ?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Action (%1) ჩავარდა:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_kab.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_kab.ts
@@ -143,6 +143,7 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="209"/>
+        <location filename="../mainwindow.cpp" line="201"/>
         <source>Change Password</source>
         <translation type="unfinished"></translation>
     </message>
@@ -154,7 +155,7 @@
     <message>
         <location filename="../mainwindow.cpp" line="179"/>
         <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="212"/>
+        <location filename="../mainwindow.cpp" line="213"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -169,12 +170,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="202"/>
+        <location filename="../mainwindow.cpp" line="203"/>
         <source>Input the new password for %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="212"/>
+        <location filename="../mainwindow.cpp" line="213"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_kab.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_kab.ts
@@ -9,32 +9,37 @@
         <translation>Iɣewwaṛen n ugraw</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Isem n ugraw:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Iseqdacen n wegraw-a:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Rnu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Rnu iseqdacen neɣ igrawen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Kkes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_ko.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_ko.ts
@@ -9,32 +9,37 @@
         <translation>그룹 설정</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>그룹 이름:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>기본값</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>그룹 ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>이 그룹에 속해 있는 사용자:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>오류</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>그룹 이름은 비워 둘 수 없습니다.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>구성원</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>선택한 항목의 속성 편집</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>추가</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>새 사용자 또는 그룹 추가</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>삭제</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>선택한 항목 삭제</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>속성</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>새로 고침</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>목록 새로 고침</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>비밀번호 변경</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>선택한 사용자 또는 그룹의 비밀번호 변경</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>확인하기</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>선택한 사용자를 삭제하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>선택한 그룹을 삭제하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>%1의 새 비밀번호 입력:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>빈 비밀번호를 설정하시겠습니까?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;작업(%1) 실패:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_lg.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_lg.ts
@@ -9,32 +9,37 @@
         <translation>Enteekateeka za guluupu</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Linnya lya guluupu:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Ekya bulijjo</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Namba ya guluupu:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Abali mu guluupu eno:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Kiremya</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Guluupu eteekwa okuba n&apos;erinnya.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Abalimu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Kyusa ebikwata ku kitangaazidwa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Yongerako</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Yongerako bakozesa oba guluupu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Gyawo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Gyawo ekitangaazidwa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Kyusa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Ddamu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Ddamu okukebera nkalala</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Kyusa akasumuluzo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Kyusa akasumuluzo ak&apos;omukozesa oba guluupu ebitangaazidwa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Kakasa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Ddala oyagala okugyawo omukozesa atangaazidwa?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Ddala oyagala okugyawo guluupu etangaazidwa?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Wandika akasumuluzo ka %1 akapya:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Ddala oyagala waleme okubawo akasumuluzo?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Ekikolwa (%1) kiremye:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_lt.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_lt.ts
@@ -9,32 +9,37 @@
         <translation>Grupės nustatymai</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Grupės pavadinimas:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Numatytoji</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Grupės ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Šiai grupei priklausantys naudotojai:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Klaida</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Grupės pavadinimas negali būti tuščias.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Nariai</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Taisyti pasirinkto elemento savybes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Pridėti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Pridėti naujus naudotojus ar grupes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Ištrinti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Ištrinti pasirinktą elementą</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Savybės</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Įkelti iš naujo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Įkelti sąrašus iš naujo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Keisti slaptažodį</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Keisti pasirinkto naudotojo ar grupės slaptažodį</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Patvirtinti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Ar tikrai norite ištrinti pasirinktą naudotoją?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Ar tikrai norite ištrinti pasirinktą grupę?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Įveskite naują slaptažodį, skirtą %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Ar tikrai norite nustatyti tuščią slaptažodį?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Veiksmas (%1) patyrė nesėkmę:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_nb_NO.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_nb_NO.ts
@@ -9,32 +9,37 @@
         <translation>Gruppeinnstillinger</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Gruppenavn:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Gruppe-ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Brukere tilhører denne gruppen:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Gruppens navn kan ikke være tomt.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Medlemmer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Rediger egenskaper for valgt element</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Legg til</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Legg til nye brukere eller grupper</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Slett</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Slett valgte element</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Egenskaper</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Gjenoppfrisk</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Gjenoppfrisk listene</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Forandre passord</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Forandre passord for valgt bruker eller gruppe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Bekreft</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Er du sikker på at du vil slette den valgte brukeren?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Er du sikker på at du vil slette den valgte gruppen?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Skriv inn det nye passordet til %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Er du sikker på at du vil bruke et tomt passord?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Handlingen (%1) mislyktes:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_nl.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_nl.ts
@@ -9,32 +9,37 @@
         <translation>Groepsinstellingen</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Groepsnaam:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Groepsid:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Gebruikers behoren tot deze groep:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Foutmelding</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Voer een groepsnaam in.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Leden</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Eigenschappen van het geselecteerde item bewerken</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Toevoegen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Voeg nieuwe gebruikers of groepen toe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Verwijder het geselecteerde item</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Eigenschappen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Verversen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Ververs de lijsten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Wachtwoord wijzigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Wijzig het wachtwoord van de geselecteerde gebruiker of groep</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Bevestigen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Weet u zeker dat u de geselecteerde gebruiker wilt verwijderen?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Weet u zeker dat u de geselecteerde groep wilt verwijderen?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Voer een nieuw wachtwoord in voor %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Weet u zeker dat u een blanco wachtwoord wilt instellen?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Actie (%1) mislukt:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_oc.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_oc.ts
@@ -9,32 +9,37 @@
         <translation>Paramètres del grop</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Nom del grop&#xa0;:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Per defaut</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Identificant del grop&#xa0;:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Utilizaires d’aqueste grop&#xa0;:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Lo nom del grop pòt pas èsser void.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Membres</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Modificar las proprietats de l’element seleccionat</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Ajustar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Ajustar d’utilizaires novèls o de grops novèls</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Suprimir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Suprimir l’element seleccionat</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Proprietats</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Actualizar las listas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Cambiar lo senhal</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Cambiar lo senhal per l’utilizaire o lo grop seleccionat</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Volètz vertadièrament suprimir l’utilizaire seleccionat&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Volètz vertadièrament suprimir lo grop seleccionat&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Picar lo senhal novèl per %1&#xa0;:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Volètz vertadièrament definir un senhal void&#xa0;?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;L’action (%1) a fracassat&#xa0;:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_pa.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_pa.ts
@@ -9,32 +9,37 @@
         <translation>ਗਰੁੱਪ ਸੈਟਿੰਗਾਂ</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>ਗਰੁੱਪ ਦਾ ਨਾਂ:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>ਮੂਲ</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ਗਰੁੱਪ ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>ਵਰਤੋਂਕਾਰ ਇਸ ਗਰੁੱਪ ਨਾਲ ਸੰਬੰਧਿਤ ਹੈ:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>ਗਲਤੀ</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>ਗਰੁੱਪ ਨਾਂ ਖਾਲੀ ਨਹੀਂ ਹੋ ਸਕਦਾ ਹੈ।</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>ਮੈਂਬਰ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>ਚੁਣੀ ਆਈਟਮਾਂ ਲਈ ਵਿਸ਼ੇਸ਼ਤਾਵਾਂ ਸੋਧੋ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>ਜੋੜੋ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>ਨਵਾਂ ਵਰਤੋਂਕਾਰ ਜਾਂ ਗਰੁੱਪ ਜੋਰੋ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>ਹਟਾਓ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>ਚੁਣੀ ਆਈਟਮ ਨੂੰ ਹਟਾਓ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>ਵਿਸ਼ੇਸ਼ਤਾਵਾਂ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>ਤਾਜ਼ਾ ਕਰੋ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>ਸੂਚੀਆਂ ਨੂੰ ਤਾਜ਼ਾ ਕਰੋ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>ਪਾਸਵਰਡ ਬਦਲੋ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>ਚੁਣੇ ਵਰਤੋਂਕਾਰ ਜਾਂ ਗਰੁੱਪ ਲਈ ਪਾਸਵਰਡ ਬਦਲੋ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>ਤਸਦੀਕ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>ਕੀ ਤੁਸੀਂ ਚੁਣੇ ਵਰਤੋਂਕਾਰ ਨੂੰ ਹਟਾਉਣਾ ਚਾਹੁੰਦੇ ਹੋ?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>ਕੀ ਤੁਸੀਂ ਚੁਣੇ ਗਰੁੱਪ ਨੂੰ ਹਟਾਉਣਾ ਚਾਹੁੰਦੇ ਹੋ?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>%1 ਲਈ ਨਵਾਂ ਪਾਸਵਰਡ ਦਿਓ:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>ਕੀ ਤੁਸੀਂ ਪਾਸਵਰਡ ਖਾਲੀ ਸੈੱਟ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Action (%1) ਫੇਲ੍ਹ ਹੈ:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_pl.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_pl.ts
@@ -9,32 +9,37 @@
         <translation>Ustawienia grup</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Nazwa grupy:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Domyślne</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ID grupy:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Użytkownicy należący do tej grupy:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Nazwa grupy nie może być pusta.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Członkowie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Edytuj właściwości zaznaczonego elementu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Dodaj</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Dodaj nowych użytkowników lub grupy</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Usuń zaznaczoną pozycję</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Właściwości</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Odśwież</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Odśwież listę</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Zmień hasło</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Zmień hasło dla zaznaczonego użytkownika lub grupy</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Potwierdź</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Czy na pewno chcesz usunąć wybranego użytkownika?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Czy na pewno chcesz usunąć wybraną grupę?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Wprowadź nowe hasło dla %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Czy na pewno chcesz ustawić puste hasło?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Działanie (%1) nie powiodło się:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_pt.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_pt.ts
@@ -9,32 +9,37 @@
         <translation>Definições do grupo</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Nome do grupo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ID do grupo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Utilizadores pertencentes a este grupo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>O nome do grupo não pode estar vazio.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Membros</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Editar propriedades do item selecionado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Adicionar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Adicionar novos utilizadores ou grupos</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Eliminar o item selecionado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Propriedades</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Recarregar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Recarregar as listas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Alterar palavra-passe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Alterar palavra-passe para o utilizador ou grupo selecionado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Confirmação</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Tem a certeza de que deseja eliminar o utilizador selecionado?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Tem a certeza de que deseja eliminar o grupo selecionado?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Introduza a nova palavra-passe para %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Tem a certeza de que deseja definir uma palavra-passe vazia?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Ação (%1) falhou:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_pt_BR.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_pt_BR.ts
@@ -9,32 +9,37 @@
         <translation>Configurações de grupo</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Nome do grupo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ID do grupo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Usuários pertencentes a este grupo:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>O nome do grupo não pode estar vazio.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Membros</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Editar propriedades do item selecionado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Adicionar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Adicionar novos usuários ou grupos</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Excluir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Excluir item selecionado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Propriedades</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Atualizar as listas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Alterar Senha</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Alterar a senha do usuário ou grupo selecionado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Confirmar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Tem certeza de que deseja excluir o usuário selecionado?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Tem certeza de que deseja excluir o grupo selecionado?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Digite a nova senha para %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Tem certeza de que não deseja definir uma senha?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;A ação (%1) falhou:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_ru.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_ru.ts
@@ -9,32 +9,37 @@
         <translation>Настройки группы</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Имя группы:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ИД группы:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Пользователи, относящиеся к этой группе:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Имя группы не может быть пустым.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Члены</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Редактировать свойства выбранной записи</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Добавить новых пользователей или группы</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Удалить выбранную запись</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Свойства</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Обновить</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Обновить списки</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Изменить пароль</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Изменить пароль для выбранного пользователя или группы</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Подтвердить</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Вы действительно хотите удалить выбранного пользователя?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Вы действительно хотите удалить выбранную группу?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Введите новый пароль для %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Уверены, что хотите установить пустой пароль?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Не удалось выполнить запрошенное действие (%1)&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_si.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_si.ts
@@ -9,32 +9,37 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_sk.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_sk.ts
@@ -9,32 +9,37 @@
         <translation>Nastavenia skupiny</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Názov skupiny:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Predvolené</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ID skupiny:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Používatelia v skupine:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Musíte zadať názov skupiny.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Členovia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Upraviť vlastnosti vybranej položky</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Pridať</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Pridať nových používateľov alebo skupiny</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Odstrániť</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Odstrániť vybranú položku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Vlastnosti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Načítať znova</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Znova načítať zoznam</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Zmeniť heslo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Zmeniť heslo vybraného používateľa či skupiny</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Potvrdiť</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Naozaj si prajete vymazať vybraného používateľa?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Naozaj si prajete vymazať vybranú skupinu?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Zadajte nové heslo pre %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Naozaj si prajete nastaviť prázdne heslo?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Akcia(%1) neúspešná:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_tr.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_tr.ts
@@ -9,32 +9,37 @@
         <translation>Grup Ayarları</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Grup adı:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Varsayılan</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>Grup ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Bu gruba ait kullanıcılar:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Hata</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Grup adı boş bırakılamaz.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Üyeler</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Seçilen ögenin özelliklerini düzenle</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Ekle</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Yeni kullanıcılar ve gruplar ekle</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Seçilen ögeyi sil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Özellikler</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Yenile</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Listeyi yenile</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Parolayı Değiştir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Seçilen kullanıcı ya da grup için parolayı değiştir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Doğrula</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Seçilen kullanıcıyı silmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Seçilen grubu silmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>%1 için yeni parolayı girin:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Parolayı boş bırakmak istediğinizden emin misiniz?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Eylem (%1) başarısız:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_uk.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_uk.ts
@@ -9,32 +9,37 @@
         <translation>Налаштування груп</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Назва групи:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>За вибором системи</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ID групи:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Користувачі, що належать до цієї групи:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Назва групи не може бути порожньою.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Члени</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Змінити властивості вибраного елемента</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Додати</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Додати нових користувачів або групи</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Вилучити</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Вилучити вибрані</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Властивості</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Оновити список</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Змінити пароль</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Змінити пароль для вибраного користувача або групи</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Підтвердити</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Ви дійсно бажаєте видалити позначеного користувача?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Ви дійсно бажаєте видалити позначену групу?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Введіть новий пароль для %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Дійсно хочете встановити порожній пароль?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Операція (%1) не виконана:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_vi.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_vi.ts
@@ -9,32 +9,37 @@
         <translation>Cài đặt nhóm</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>Tên nhóm:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>Mặc định</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>ID nhóm:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>Những người dùng trong nhóm này:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>Lỗi</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>Tên nhóm không được phép để trống.</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>Thành viên</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>Chỉnh sửa thuộc tính của mục đã chọn</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>Thêm</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>Thêm nhóm hoặc người dùng mới</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>Xóa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>Xóa mục đã chọn</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>Thuộc tính</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>Làm mới</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>Làm mới danh sách</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>Thay đổi mật khẩu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>Thay đổi mật khẩu cho nhóm hoặc người dùng đã chọn</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>Xác nhận</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>Bạn có chắc muốn xóa người dùng đã chọn?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>Bạn có chắc muốn xóa nhóm đã chọn?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>Nhập mật khẩu mới cho %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>Bạn có chắc là muốn để trống mật khẩu?</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;Hành động (%1) thất bại:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_zh_CN.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_zh_CN.ts
@@ -9,32 +9,37 @@
         <translation>组设置</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>组名称:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>组 ID:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>组成员:</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>组名称不得为空。</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>成员</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>编辑所选项的属性</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>新增</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>新增用户或组</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>删除所选项</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>属性</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>刷新列表</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>更改密码</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>更改所选用户或组的密码</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>确认</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>是否确认删除所选的用户？</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>是否确认删除所选的组？</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>输入 %1 的新密码:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>是否确认设置空密码？</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;动作 (%1) 失败：&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/translations/lxqt-admin-user_zh_TW.ts
+++ b/lxqt-admin-user/translations/lxqt-admin-user_zh_TW.ts
@@ -9,32 +9,37 @@
         <translation>群組設定</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="20"/>
+        <location filename="../groupdialog.ui" line="29"/>
         <source>Group name:</source>
         <translation>群組名稱：</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="30"/>
+        <location filename="../groupdialog.ui" line="36"/>
         <source>Default</source>
         <translation>預設</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="40"/>
+        <location filename="../groupdialog.ui" line="22"/>
         <source>Group ID:</source>
         <translation>群組 ID：</translation>
     </message>
     <message>
-        <location filename="../groupdialog.ui" line="47"/>
+        <location filename="../groupdialog.ui" line="63"/>
         <source>Users belong to this group:</source>
         <translation>群組成員：</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.ui" line="70"/>
+        <source>Main members:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>Error</source>
         <translation>錯誤</translation>
     </message>
     <message>
-        <location filename="../groupdialog.cpp" line="64"/>
+        <location filename="../groupdialog.cpp" line="81"/>
         <source>The group name cannot be empty.</source>
         <translation>群組名稱不可空白。</translation>
     </message>
@@ -98,84 +103,89 @@
     </message>
     <message>
         <location filename="../mainwindow.ui" line="121"/>
+        <source>Main Members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="126"/>
         <source>Members</source>
         <translation>成員</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="188"/>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>Edit properties of the selected item</source>
         <translation>編輯所選項目的屬性</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="161"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Add</source>
         <translation>新增</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="164"/>
+        <location filename="../mainwindow.ui" line="169"/>
         <source>Add new users or groups</source>
         <translation>新增使用者或群組</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="178"/>
         <source>Delete</source>
         <translation>刪除</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="176"/>
+        <location filename="../mainwindow.ui" line="181"/>
         <source>Delete selected item</source>
         <translation>刪除所選項目</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="185"/>
+        <location filename="../mainwindow.ui" line="190"/>
         <source>Properties</source>
         <translation>屬性</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
+        <location filename="../mainwindow.ui" line="202"/>
         <source>Refresh</source>
         <translation>重新整理</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="200"/>
+        <location filename="../mainwindow.ui" line="205"/>
         <source>Refresh the lists</source>
         <translation>重新整理列表</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="209"/>
-        <location filename="../mainwindow.cpp" line="201"/>
+        <location filename="../mainwindow.ui" line="214"/>
+        <location filename="../mainwindow.cpp" line="202"/>
         <source>Change Password</source>
         <translation>變更密碼</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="212"/>
+        <location filename="../mainwindow.ui" line="217"/>
         <source>Change password for the selected user or group</source>
         <translation>所選使用者或群組進行變更密碼</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
-        <location filename="../mainwindow.cpp" line="191"/>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="180"/>
+        <location filename="../mainwindow.cpp" line="192"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Confirm</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="179"/>
+        <location filename="../mainwindow.cpp" line="180"/>
         <source>Are you sure you want to delete the selected user?</source>
         <translation>確定要刪除所選的使用者？</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="191"/>
+        <location filename="../mainwindow.cpp" line="192"/>
         <source>Are you sure you want to delete the selected group?</source>
         <translation>確定要刪除所選的群組？</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="203"/>
+        <location filename="../mainwindow.cpp" line="204"/>
         <source>Input the new password for %1:</source>
         <translation>輸入 %1 的新設密碼：</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="213"/>
+        <location filename="../mainwindow.cpp" line="214"/>
         <source>Are you sure you want to set a empty password?</source>
         <translation>確定要設定空白密碼？</translation>
     </message>
@@ -256,7 +266,7 @@
 <context>
     <name>UserManager</name>
     <message>
-        <location filename="../usermanager.cpp" line="229"/>
+        <location filename="../usermanager.cpp" line="230"/>
         <source>&lt;strong&gt;Action (%1) failed:&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</source>
         <translation>&lt;strong&gt;動作 (%1) 失敗：&lt;/strong&gt;&lt;br/&gt;&lt;pre&gt;%2&lt;/pre&gt;</translation>
     </message>

--- a/lxqt-admin-user/usermanager.cpp
+++ b/lxqt-admin-user/usermanager.cpp
@@ -88,11 +88,12 @@ void UserManager::loadUsersAndGroups()
             continue;
         UserInfo* user = new UserInfo(pw);
         mUsers.append(user);
-        // add groups to this user
-        for(const GroupInfo* group: std::as_const(mGroups)) {
-            if(group->hasMember(user->name())) {
+        // add groups to this user and add this user to their group's main members
+        for(GroupInfo* group: mGroups) {
+            if(group->hasMember(user->name()))
                 user->addGroup(group->name());
-            }
+            if(user->gid() == group->gid())
+                group->addMainMember(user->name());
         }
     }
     endpwent();

--- a/lxqt-admin-user/usermanager.h
+++ b/lxqt-admin-user/usermanager.h
@@ -153,31 +153,50 @@ public:
     const QStringList& members() const {
         return mMembers;
     }
+    const QStringList& mainMembers() const {
+        return mMainMembers;
+    }
 
     void setMembers(const QStringList& members) {
         mMembers = members;
+    }
+    void setMainMembers(const QStringList& members) {
+        mMainMembers = members;
     }
 
     void addMember(const QString& userName) {
         mMembers.append(userName);
     }
+    void addMainMember(const QString& userName) {
+        mMainMembers.append(userName);
+    }
 
     void removeMember(const QString& userName) {
         mMembers.removeOne(userName);
+    }
+    void removeMainMember(const QString& userName) {
+        mMainMembers.removeOne(userName);
     }
 
     void removeAllMemberss() {
         mMembers.clear();
     }
+    void removeAllMainMembers() {
+        mMainMembers.clear();
+    }
 
     bool hasMember(const QString& userName) const {
         return mMembers.contains(userName);
+    }
+    bool hasMainMember(const QString& userName) const {
+        return mMainMembers.contains(userName);
     }
 
 private:
     gid_t mGid;
     QString mName;
     QStringList mMembers;
+    QStringList mMainMembers;
 };
 
 class UserManager : public QObject


### PR DESCRIPTION
Adds the ability to see main members in groups. (Inverse of a user's main group)

Also fixes the translation file [lxqt-admin-user_kab.ts](https://github.com/lxqt/lxqt-admin/commit/8a7d7f615697812cb9dadb6d281f8d7e7b4a9956)

As Im new to C++, I just want to make sure this is safe and good:
```cpp
// add groups to this user and add this user to their group's main members
for(GroupInfo* group: mGroups) { // Removed the "std::as_const(mGroups)", replaced with "mGroups"
    if(group->hasMember(user->name()))
        user->addGroup(group->name());
    if(user->gid() == group->gid())
        group->addMainMember(user->name());
}
```

## Screenshots
![Screenshot_20250313_212956](https://github.com/user-attachments/assets/b7bb84dc-cb36-4b2e-884b-afbcb5708c13)
![Screenshot_20250313_213031](https://github.com/user-attachments/assets/926f7408-a6be-4b27-9b08-4bb31624f6c8)
