### PR TITLE
Do not prompt for new user password after cancelled auth

### DIFF
--- a/lxqt-admin-user/mainwindow.cpp
+++ b/lxqt-admin-user/mainwindow.cpp
@@ -150,10 +150,12 @@ void MainWindow::onAdd()
         UserDialog dlg(mUserManager, &newUser, this);
         if(dlg.exec() == QDialog::Accepted)
         {
-            mUserManager->addUser(&newUser);
-            QByteArray newPasswd;
-            if(getNewPassword(newUser.name(), newPasswd)) {
-                mUserManager->changePassword(&newUser, newPasswd);
+            if(mUserManager->addUser(&newUser))
+            {
+                QByteArray newPasswd;
+                if(getNewPassword(newUser.name(), newPasswd)) {
+                    mUserManager->changePassword(&newUser, newPasswd);
+                }
             }
         }
     }


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt-admin/issues/289.

For adding users, check if auth failed before prompting for new password.