### PR TITLE
Removed OnlyShowin=LXQt

### DIFF
--- a/lxqt-admin-time/lxqt-admin-time.desktop.in
+++ b/lxqt-admin-time/lxqt-admin-time.desktop.in
@@ -3,6 +3,5 @@ Type=Application
 Exec=lxqt-admin-time
 Icon=preferences-system-time
 Categories=LXQt;Settings;DesktopSettings;Qt;
-OnlyShowIn=LXQt;
 
 #TRANSLATIONS_DIR=translations


### PR DESCRIPTION
Similar to https://github.com/lxqt/lxqt-admin/pull/313, this is a generic system tool (GUI for `timedatectl`) and not specific for the LXQt session.