### PR TITLE
Tidy variables in lxqt-admin-time timezone files

### DIFF
--- a/lxqt-admin-time/timezone.cpp
+++ b/lxqt-admin-time/timezone.cpp
@@ -28,7 +28,7 @@
 #include "timezone.h"
 #include "ui_timezone.h"
 
-TimezonePage::TimezonePage(const QStringList & zones, const QString & currentimezone, QWidget *parent) :
+TimezonePage::TimezonePage(const QStringList &zones, const QString &currentTimezone, QWidget *parent) :
     QWidget(parent),
     ui(new Ui::Timezone),
     mZoneChanged(false),
@@ -36,8 +36,8 @@ TimezonePage::TimezonePage(const QStringList & zones, const QString & currentime
 {
     ui->setupUi(this);
 
-    if (!currentimezone.isEmpty())
-        ui->label_timezone->setText(currentimezone);
+    if (!currentTimezone.isEmpty())
+        ui->label_timezone->setText(currentTimezone);
     else
         ui->label_timezone->setText(tr("None"));
 

--- a/lxqt-admin-time/timezone.h
+++ b/lxqt-admin-time/timezone.h
@@ -40,10 +40,10 @@ class TimezonePage : public QWidget
     Q_OBJECT
 
 public:
-    explicit TimezonePage(const QStringList & zones, const QString & currentimezone, QWidget *parent = 0);
+    explicit TimezonePage(const QStringList &zones, const QString &currentTimezone, QWidget *parent = 0);
     ~TimezonePage();
     QString timezone() const;
-    inline bool isChanged() const {return mZoneChanged;}
+    inline bool isChanged() const { return mZoneChanged; }
 
 public slots:
     void reload();
@@ -58,7 +58,6 @@ private slots:
 private:
     Ui::Timezone *ui;
     bool mZoneChanged;
-    QString mCurrentTimeZone;
     QStringList mZonesList;
 };
 


### PR DESCRIPTION
Add polish to title

Before:
<img width="514" height="184" alt="woeifoweifj" src="https://github.com/user-attachments/assets/ceb94685-dc4f-49eb-b663-868160cc5cc2" />

After:
<img width="492" height="214" alt="asdfasdf" src="https://github.com/user-attachments/assets/bc0936a6-df25-4185-a536-a81350d1d52a" />